### PR TITLE
Add repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,9 @@
   },
   "keywords": [
     "ember-addon"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/simplabs/ember-cli-simple-auth"
+  }
 }


### PR DESCRIPTION
This removes the warning about this from npm when running `npm install`.
